### PR TITLE
Try installing libjpeg-dev to fix pypy3.10 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,11 @@ jobs:
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
             ${{ runner.os }}-pip-
 
+      - name: Install OS-level dependencies (Linux)
+        if: runner.os == 'Linux' && matrix.python-version == "pypy3.10"
+        run: |
+          sudo apt-get install -y libjpeg-dev
+
       - name: Install dependencies
         run: |
           python -m pip install -U pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install OS-level dependencies (Linux)
-        if: runner.os == 'Linux' && matrix.python-version == "pypy3.10"
+        if: runner.os == 'Linux' && matrix.python-version == 'pypy3.10'
         run: |
           sudo apt-get install -y libjpeg-dev
 


### PR DESCRIPTION
Currently they fail with

    The headers or library files could not be found for jpeg,
    a required dependency when compiling Pillow from source.

but only for pypy310 -- Python 3.8 works fine (the rest of the Pythons were skipped due to fail-early defaults).